### PR TITLE
Fix inherited timing points with positive MpB

### DIFF
--- a/Mapping_Tools_Core/BeatmapHelper/TimingStuff/TimingPoint.cs
+++ b/Mapping_Tools_Core/BeatmapHelper/TimingStuff/TimingPoint.cs
@@ -200,7 +200,7 @@ namespace Mapping_Tools_Core.BeatmapHelper.TimingStuff {
         /// </summary>
         /// <returns></returns>
         public double GetSliderVelocity() {
-            return !Uninherited && MpB < 0 ? -100 / MpB : 1;
+            return Uninherited || MpB >= 0 ? 1 : -100 / MpB;
         }
 
         /// <summary>

--- a/Mapping_Tools_Core/BeatmapHelper/TimingStuff/TimingPoint.cs
+++ b/Mapping_Tools_Core/BeatmapHelper/TimingStuff/TimingPoint.cs
@@ -200,11 +200,7 @@ namespace Mapping_Tools_Core.BeatmapHelper.TimingStuff {
         /// </summary>
         /// <returns></returns>
         public double GetSliderVelocity() {
-            if (!Uninherited) {
-                return MpB < 0 ? -100 / MpB : 1;
-            }
-
-            return 1;
+            return !Uninherited && Mpb < 0 ? -100 / Mpb : 1;
         }
 
         /// <summary>

--- a/Mapping_Tools_Core/BeatmapHelper/TimingStuff/TimingPoint.cs
+++ b/Mapping_Tools_Core/BeatmapHelper/TimingStuff/TimingPoint.cs
@@ -200,7 +200,7 @@ namespace Mapping_Tools_Core.BeatmapHelper.TimingStuff {
         /// </summary>
         /// <returns></returns>
         public double GetSliderVelocity() {
-            return !Uninherited && Mpb < 0 ? -100 / Mpb : 1;
+            return !Uninherited && MpB < 0 ? -100 / MpB : 1;
         }
 
         /// <summary>

--- a/Mapping_Tools_Core/BeatmapHelper/TimingStuff/TimingPoint.cs
+++ b/Mapping_Tools_Core/BeatmapHelper/TimingStuff/TimingPoint.cs
@@ -196,12 +196,12 @@ namespace Mapping_Tools_Core.BeatmapHelper.TimingStuff {
         /// <summary>
         /// Grabs the current slider velocity multiplier from the <see cref="TimingPoint"/>
         /// assuming this is an inherited timing point.
-        /// Returns 1x slider velocity if this is an uninherited timing point.
+        /// Returns 1x slider velocity if this is an uninherited timing point or if MpB is positive.
         /// </summary>
         /// <returns></returns>
         public double GetSliderVelocity() {
             if (!Uninherited) {
-                return -100 / MpB;
+                return MpB < 0 ? -100 / MpB : 1;
             }
 
             return 1;


### PR DESCRIPTION
Really old maps encode inherited timing points like this for some reason:
```
[TimingPoints]
370,428.571428571429,4,1,0,100,1
55655,428.571428571429,4,2,0,100,0
68083,428.571428571429,4,1,0,100,0
```
osu! just pretends any inherited timing point with `MpB >= 0` is a 1x slider velocity timing point.